### PR TITLE
replace docxtools with formatdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.Renviron
 .Rproj.user
 .Rhistory
 .RData

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     tibble,
     units
 Suggests:
-    docxtools,
+    formatdown,
     kableExtra,
     knitr,
     rmarkdown

--- a/vignettes/hydraulics_vignette.Rmd
+++ b/vignettes/hydraulics_vignette.Rmd
@@ -98,11 +98,31 @@ tbl <- water_table(units = "SI")
 tbl
 ```
 
-The table can be reformatted to something more attractive using the _kableExtra_ and _docxtools_ packages.
-```{r waterprops-table2}
-unitlist <- sapply(unname(tbl),units::deparse_unit)
+The table can be reformatted to something more attractive using the _kableExtra_ and _formatdown_ packages.
+
+```{r waterprops-table2b}
+unitlist <- sapply(unname(tbl), units::deparse_unit)
 colnames <- names(tbl)
-tbl <- docxtools::format_engr(units::drop_units(tbl), sigdig = c(0, 4, 4, 4, 4, 4, 3, 3))
+tbl <- units::drop_units(tbl)
+
+# Format as integer
+cols_we_want = c("Temp", "Spec_Weight")
+tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_decimal(x, digits = 0)}
+)
+
+# Format to 4 digits, omit power of ten notation
+tbl$Density <- formatdown::format_power(tbl$Density, digits = 4, omit_power = c(0, 3))
+
+# Format using power-of-ten notation to 4 significant digits
+cols_we_want = c("Viscosity", "Kinem_Visc", "Sat_VP")
+tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 4, format = "engr")}
+)
+
+# Format using power-of-ten notation to 3 significant digits
+cols_we_want = c("Surf_Tens", "Bulk_Mod")
+tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 3, format = "engr")}
+)
+
 tbl2 <- knitr::kable(tbl, col.names = unitlist, align = "c", format = "html")
 kableExtra::add_header_above(tbl2, header = colnames, line = F, align = "c")
 ```

--- a/vignettes/hydraulics_vignette.Rmd
+++ b/vignettes/hydraulics_vignette.Rmd
@@ -98,35 +98,26 @@ tbl <- water_table(units = "SI")
 tbl
 ```
 
-The table can be reformatted to something more attractive using the _kableExtra_ and _formatdown_ packages.
-
-```{r waterprops-table2b}
-unitlist <- sapply(unname(tbl), units::deparse_unit)
+The table can be reformatted to something more attractive using the [kableExtra](https://cran.r-project.org/package=kableExtra) and [formatdown](https://cran.r-project.org/package=formatdown) packages.
+```{r waterprops-table2}
+unitlist <- sapply(unname(tbl),units::deparse_unit)
 colnames <- names(tbl)
 tbl <- units::drop_units(tbl)
-
-# Format as integer
-cols_we_want = c("Temp", "Spec_Weight")
-tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_decimal(x, digits = 0)}
+# Format column as integer
+tbl$Temp <- formatdown::format_decimal(tbl$Temp, digits = 0)
+# Format column with one decimal
+tbl$Density <- formatdown::format_decimal(tbl$Density, digits = 1)
+# Format multiple columns using power-of-ten notation to 4 significant digits
+cols_we_want = c("Spec_Weight", "Viscosity", "Kinem_Visc", "Sat_VP")
+tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 4, format = "sci", omit_power = c(-1, 4))}
 )
-
-# Format to 4 digits, omit power of ten notation
-tbl$Density <- formatdown::format_power(tbl$Density, digits = 4, omit_power = c(0, 3))
-
-# Format using power-of-ten notation to 4 significant digits
-cols_we_want = c("Viscosity", "Kinem_Visc", "Sat_VP")
-tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 4, format = "engr")}
-)
-
-# Format using power-of-ten notation to 3 significant digits
+# Format multiple columns using power-of-ten notation to 3 significant digits
 cols_we_want = c("Surf_Tens", "Bulk_Mod")
-tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 3, format = "engr")}
+tbl[, cols_we_want] <- lapply(tbl[, cols_we_want], function (x) {formatdown::format_power(x, digits = 3, format = "sci", omit_power = c(-1, 4))}
 )
-
 tbl2 <- knitr::kable(tbl, col.names = unitlist, align = "c", format = "html")
 kableExtra::add_header_above(tbl2, header = colnames, line = F, align = "c")
 ```
-
 While the _hydraulics_ package is focused on water, properties of the atmosphere are important for characterizing the interaction of water with air. The is particularly important for phenomena such as evaporation and condensation. Selected characteristics of the standard atmosphere, as determined by the International Civil Aviation Organization (ICAO), are included in the package. Three functions return different properties of the standard atmosphere:
 ```{r waterprops-atmtable1, echo=FALSE}
 knitr::kable(data.frame(Function=c("atmtemp","atmpres","atmdens"), Returns=c("Atmospheric Temperature","Pressure","Density")), format="pipe", padding=0)


### PR DESCRIPTION
In your vignette, you illustrate using my **docxtools** package to create power-of-ten notation for display in a table. I was hoping to archive **docxtools** (basically removing it from active use on CRAN) because it is time-consuming to maintain (too many dependencies that keep changing and break my code). 

My newer **formatdown** package contains improved power-of-ten (and other) notation features---and is written with fewer (and more robust) dependencies. 

In this pull request, I created a new branch with changes to replace the **docxtools** example in the vignette with relevant **formatdown** functions to achieve the same result. I also edited the "Suggests" section of the Description file. 

Thanks for considering this revision!




